### PR TITLE
Fixed bug in harmony parser.

### DIFF
--- a/rnn/music/_note_utils.py
+++ b/rnn/music/_note_utils.py
@@ -10,6 +10,7 @@ _note_symbol_to_number = {
     "D#": 3,
     "Fb": 4,
     "E": 4,
+    "E#": 5,
     "F": 5,
     "Gb": 6,
     "F#": 6,

--- a/rnn/music/song.py
+++ b/rnn/music/song.py
@@ -376,13 +376,16 @@ class HarmonySongParser(SongParser):
         for element in elements:
             # First, find out if the element is a note or a harmony symbol.
             if element.name == "note":
-                note_duration = int(element.find("duration").string)
+                note_duration = (
+                    int(element.find("duration").string) * self.duration_multiplier
+                )
                 # The offset must be updated to keep track of the position
                 #   of the measure that is currently being parsed.
                 offset += note_duration
             else:
                 harmony = self._parse_one_harmony_symbol(element, offset)
                 self.harmony_representation.append(harmony)
+        assert offset == 48
 
     def _convert_and_augment_training_data(
         self, input_length: int, target_length: int


### PR DESCRIPTION
The bug occurred because the music .xml files are not consistent with regard to the representation of the chord durations; therefore, the durations have to be multiplied by a scaling constant. For the melody parser, this was already implemented; for the harmony parser, this was overlooked.